### PR TITLE
Fresh store per call to server app

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ app('/foos/123').then(({ result }) => result)
 
 ## Required params
 
-The only property needed to init both the server and client apps is a React Router routes configuration. You can provide this in any form that react Router accpets.
+The only property needed to init both the server and client apps is a React Router `routes` configuration. You can provide this in any form that react Router accpets.
 
 ## Optional Params
 
@@ -58,6 +58,16 @@ The only property needed to init both the server and client apps is a React Rout
 `renderDocument`
 
 A function which will take the result of calling `renderToString` on your app, along with the store, and return the final markup.
+
+`createStore`
+
+A function which will take the `initialState` option as it's only arg and return a redux store. You must leave the `store` option (see below) blank for this to be used.
+
+Use this option if you want a new instance of your redux store per server request (this is very likely what you want).
+
+`initialState`
+
+To be used with `createStore`, this will be passed to createStore to initialize your redux store.
 
 ### Client
 
@@ -77,7 +87,7 @@ A function called in the event that React Router was redirected in the process o
 
 `store`
 
-A Redux store which will be passed to a `<Provider />`
+A Redux store which will be passed to a `<Provider />`.
 
 `basepath`
 

--- a/source/server/test.js
+++ b/source/server/test.js
@@ -110,6 +110,33 @@ describe('createServerApp', () => {
       }).catch(done)
     })
 
+    it('takes createStore() and initalState options to create a fresh store for each request, unless the store option is provided', (done) => {
+      const routes = { path: '/', component: () => React.createElement('div', null, '') }
+      const stores = []
+
+      const app = createServerApp({
+        routes,
+        initialState: { foo: 'Foo' },
+        createStore (initialState) {
+          const storeInstance = createStore((state) => state, initialState)
+          stores.push(storeInstance)
+          return storeInstance
+        }
+      })
+
+      Promise.all([
+        app('/'),
+        app('/')
+      ]).then(() => {
+        const store1 = stores[0]
+        const store2 = stores[1]
+        expect(store1.getState().foo).to.eq('Foo')
+        expect(store2.getState().foo).to.eq('Foo')
+        expect(store1).to.not.eq(store2)
+        done()
+      }).catch(done)
+    })
+
     it('it takes a basepath option which will prefix all route matching and links', (done) => {
       const routes = {
         path: '/',

--- a/source/shared.js
+++ b/source/shared.js
@@ -7,7 +7,9 @@ const defaultCreateLocals = ({ params, store, query }) => ({
   query
 })
 
-const defaultStore = () => createStore((state) => state, {})
+const defaultStore = (state = {}) => (
+  createStore((state) => state, state)
+)
 
 const ensureRoutes = (name) => {
   throw new Error(`No routes key was found on options passed to ${name}`)


### PR DESCRIPTION
This was an initial oversight, but can still be released as a minor :)

This version allows you to pass a store factory and initial state to `createServer`, calls to the returned app instance will each create a unique store. Which is probably what we want.