### PR TITLE
Swap scroll-behaviour with react-router-scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "dependencies": {
     "react-redux": "^4.4.5",
     "react-router": "^3.0.2",
+    "react-router-scroll": "^0.4.1",
     "redial": "^0.4.1",
-    "redux": "^3.5.2",
-    "scroll-behavior": "^0.8.1"
+    "redux": "^3.5.2"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
     "chai": "^3.5.0",
-    "es5-shim": "^4.5.9",
     "es6-promise": "^3.2.1",
+    "es6-shim": "^0.35.3",
     "history": "^2.1.1",
     "mocha": "^2.4.5",
     "phantomjs-prebuilt": "^2.1.7",
-    "sinon": "^1.17.4",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
+    "sinon": "^1.17.4",
     "tape": "^4.5.1",
     "testling": "^1.7.1"
   }

--- a/source/client/index.js
+++ b/source/client/index.js
@@ -61,15 +61,23 @@ module.exports = ({
     })
   })
 
-  const scrollToHashMiddleware = useScroll((prevRouterProps, { location }) => {
-    if (location.hash) {
-      const e = document.querySelector(location.hash)
-      if (e) {
-        e.scrollIntoView()
-        return false
+  const scrollBehaviourMiddleware = useScroll((prevRouterProps, routerProps) => {
+    const scrollToAnchor = (prevRouterProps, { location }) => {
+      if (location.hash) {
+        const e = document.querySelector(location.hash)
+        if (e) {
+          e.scrollIntoView()
+          return false
+        }
       }
+      return true
     }
-    return true
+    const scrollBehaviourRoute = routerProps.routes.find((route) =>
+      route.scrollBehaviour)
+    const customScrollBehaviour = scrollBehaviourRoute
+      ? scrollBehaviourRoute.scrollBehaviour
+      : scrollToAnchor
+    return customScrollBehaviour(prevRouterProps, routerProps)
   })
 
   return () => (
@@ -77,7 +85,7 @@ module.exports = ({
       React.createElement(Router, {
         history: basedHistory,
         routes,
-        render: applyRouterMiddleware(scrollToHashMiddleware)
+        render: applyRouterMiddleware(scrollBehaviourMiddleware)
       })
     )
   )

--- a/source/client/index.js
+++ b/source/client/index.js
@@ -1,7 +1,12 @@
 const React = require('react')
-const withScroll = require('scroll-behavior').default
+const useScroll = require('react-router-scroll/lib/useScroll')
 const { Provider } = require('react-redux')
-const { Router, useRouterHistory, match } = require('react-router')
+const {
+  Router,
+  useRouterHistory,
+  applyRouterMiddleware,
+  match
+} = require('react-router')
 const { createHistory } = require('history')
 const { trigger } = require('redial')
 
@@ -56,13 +61,24 @@ module.exports = ({
     })
   })
 
-  const hashIgnoringHistory = withScroll(basedHistory, (_prevLoc, { hash } = {}) => (
-    !hash
-  ))
+  const scrollToHashMiddleware = useScroll((prevRouterProps, { location }) => {
+    if (location.hash) {
+      const e = document.querySelector(location.hash)
+      if (e) {
+        e.scrollIntoView()
+        return false
+      }
+    }
+    return true
+  })
 
   return () => (
     React.createElement(Provider, { store },
-      React.createElement(Router, { history: hashIgnoringHistory, routes })
+      React.createElement(Router, {
+        history: basedHistory,
+        routes,
+        render: applyRouterMiddleware(scrollToHashMiddleware)
+      })
     )
   )
 }

--- a/source/client/test.js
+++ b/source/client/test.js
@@ -1,4 +1,4 @@
-require('es5-shim')
+require('es6-shim')
 const { polyfill } = require('es6-promise')
 typeof Promise === 'undefined' && polyfill()
 


### PR DESCRIPTION
Uses react router middleware to stop reloads and scroll to a hash when found