### PR TITLE
Redial allows to defer certain data fetching operations to the client.

### DIFF
--- a/source/client/index.js
+++ b/source/client/index.js
@@ -53,6 +53,7 @@ module.exports = ({
       const locals = createLocals({ params, store, query })
 
       trigger('fetch', components, locals)
+      trigger('defer', components, locals)
     })
   })
 


### PR DESCRIPTION
Update boiler-room-runner to support this feature.