### PR TITLE
Add back removed 'defer' method for client

### DIFF
--- a/source/client/index.js
+++ b/source/client/index.js
@@ -52,6 +52,7 @@ const onLocationChange = ({
     const locals = createLocals({ params, store, query })
 
     trigger('fetch', components, locals)
+    trigger('defer', components, locals)
   })
 }
 


### PR DESCRIPTION
The `defer` method provides a hook which can be called only on the client and not the server, in the case where dynamic data is to be fetched only client-side