### PR TITLE
Add hook for server-only actions

### DIFF
--- a/source/server/index.js
+++ b/source/server/index.js
@@ -109,7 +109,9 @@ module.exports = ({
         const { query } = location
         const locals = createLocals({ params, query, store: storeInstance })
 
-        trigger('fetch', components, locals).then((res) => {
+        trigger('advance', components, locals).then(() => (
+          trigger('fetch', components, locals)
+        )).then((res) => {
           const content = renderApp({ props, store: storeInstance })
           const state = storeInstance.getState()
           const result = renderDocument({


### PR DESCRIPTION
Particularly relevant for the increasing number of served React Apps we have. The PS requirement being that we pull lots of things from a CMS, but we don't want that same call happening in the client.